### PR TITLE
Replace Open Source TimeCard with Quantum TimeCard

### DIFF
--- a/Implementation/Xilinx/TimeCard/Readme.md
+++ b/Implementation/Xilinx/TimeCard/Readme.md
@@ -1,4 +1,4 @@
-# Описание дизайна Open Source TimeCard
+# Описание дизайна Quantum TimeCard
 ## Содержание
 
 [1. Обзор дизайна](#1-design-overview)
@@ -22,8 +22,8 @@
 <a id="1-design-overview"></a>
 ## 1. Обзор дизайна
 
-Исходный дизайн Open Source TimeCard включает открытые IP‑ядра от [NetTimeLogic](https://www.nettimelogic.com/) и свободно используемые IP‑ядра от [Xilinx](https://www.xilinx.com/).
-В дизайне Open Source TimeCard используются следующие ядра.
+Исходный дизайн Quantum TimeCard включает открытые IP‑ядра от [NetTimeLogic](https://www.nettimelogic.com/) и свободно используемые IP‑ядра от [Xilinx](https://www.xilinx.com/).
+В дизайне Quantum TimeCard используются следующие ядра.
 
 |Ядро|Поставщик|Описание|
 |----|:----:|-----------|

--- a/Implementation/Xilinx/TimeCard_200T/Readme.md
+++ b/Implementation/Xilinx/TimeCard_200T/Readme.md
@@ -1,4 +1,4 @@
-# Описание дизайна Open Source TimeCard 200T
+# Описание дизайна Quantum TimeCard 200T
 ## Содержание
 
 [1. Обзор дизайна](#1-design-overview)
@@ -22,7 +22,7 @@
 <a id="1-design-overview"></a>
 ## 1. Обзор дизайна
 
-Исходный дизайн Open Source TimeCard 200T включает открытые IP‑ядра от [NetTimeLogic](https://www.nettimelogic.com/) и свободно используемые IP‑ядра от [Xilinx](https://www.xilinx.com/).
+Исходный дизайн Quantum TimeCard 200T включает открытые IP‑ядра от [NetTimeLogic](https://www.nettimelogic.com/) и свободно используемые IP‑ядра от [Xilinx](https://www.xilinx.com/).
 В дизайне используются следующие ядра.
 
 |Ядро|Поставщик|Описание|

--- a/Implementation/Xilinx/TimeCard_LitePcie/Readme.md
+++ b/Implementation/Xilinx/TimeCard_LitePcie/Readme.md
@@ -25,7 +25,7 @@
 Требуется дополнительный скрипт PostSynth.tcl, который вызывается после Synthesis.
 
 
-# Описание дизайна Open Source TimeCard
+# Описание дизайна Quantum TimeCard
 ## Содержание
 
 [1. Обзор дизайна](#1-design-overview)
@@ -49,7 +49,7 @@
 <a id="1-design-overview"></a>
 ## 1. Обзор дизайна
 
-Исходный дизайн Open Source TimeCard включает открытые IP‑ядра от [NetTimeLogic](https://www.nettimelogic.com/) и бесплатные IP‑ядра от [Xilinx](https://www.xilinx.com/).
+Исходный дизайн Quantum TimeCard включает открытые IP‑ядра от [NetTimeLogic](https://www.nettimelogic.com/) и бесплатные IP‑ядра от [Xilinx](https://www.xilinx.com/).
 Дополнительно используется предварительно сгенерированная версия [LitePCIe](https://github.com/enjoy-digital/litepcie), поддерживающая MSI‑X и PTM.
 Используемые ядра:
 

--- a/Implementation/Xilinx/TimeCard_Production/Readme.md
+++ b/Implementation/Xilinx/TimeCard_Production/Readme.md
@@ -1,4 +1,4 @@
-# Описание дизайна Open Source TimeCard (Production)
+# Описание дизайна Quantum TimeCard (Production)
 ## Содержание
 
 [1. Обзор дизайна](#1-design-overview)
@@ -22,7 +22,7 @@
 <a id="1-design-overview"></a>
 ## 1. Обзор дизайна
 
-Исходный дизайн Open Source TimeCard включает открытые IP‑ядра от [NetTimeLogic](https://www.nettimelogic.com/) и бесплатные IP‑ядра от [Xilinx](https://www.xilinx.com/).
+Исходный дизайн Quantum TimeCard включает открытые IP‑ядра от [NetTimeLogic](https://www.nettimelogic.com/) и бесплатные IP‑ядра от [Xilinx](https://www.xilinx.com/).
 Используются следующие ядра.
 
 |Ядро|Поставщик|Описание|

--- a/Ips/Readme.md
+++ b/Ips/Readme.md
@@ -1,4 +1,4 @@
-# IP‑ядра FPGA Open Source Time Card
+# IP‑ядра FPGA Quantum TimeCard
 
 В папке содержатся файлы пользовательских IP‑ядер, которые используются в проекте TimeCard.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Структура FPGA Open Source Time Card
+# Структура FPGA Quantum TimeCard
 
-Репозиторий FPGA Open Source TimeCard структурирован как показано ниже
+Репозиторий FPGA Quantum TimeCard структурирован как показано ниже
 
 ```bash
     │
@@ -74,7 +74,7 @@
 ```
 
 ## Реализация
-FPGA реализации TimeCard разделены в зависимости от поставщика/версии. В настоящее время доступна только Xilinx реализация Open Source Timecard. 
+FPGA реализации TimeCard разделены в зависимости от поставщика/версии. В настоящее время доступна только Xilinx реализация Quantum TimeCard. 
 Главная папка проекта находится по пути [*/[ВАШ_ПУТЬ]/Implementation/Xilinx/TimeCard*](implementation/Xilinx/TimeCard/).
 
 В этой папке находятся файлы, зависящие от поставщика и реализации:


### PR DESCRIPTION
Rename 'Open Source TimeCard' to 'Quantum TimeCard' across the project.

---
<a href="https://cursor.com/background-agent?bcId=bc-fa13c284-463d-4b49-b93e-4c073af6b0c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fa13c284-463d-4b49-b93e-4c073af6b0c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

